### PR TITLE
Add support for editing and extracting the loop value in tempo files

### DIFF
--- a/src/main/kotlin/rhmodding/tickompiler/gameextractor/GameExtractor.kt
+++ b/src/main/kotlin/rhmodding/tickompiler/gameextractor/GameExtractor.kt
@@ -74,7 +74,6 @@ class GameExtractor(val allSubs: Boolean) {
                 val seconds = buffer.getInt(addr - 0x100000 + 4) / 32000.0 // will not work with unsigned but not important
                 val bpm = 60 * beats / seconds
                 val loop = buffer.getInt(addr - 0x100000 + 8)
-                println("${loop}")
                 s += "${correctlyRoundDouble(bpm, DECIMALS)} ${correctlyRoundDouble(beats.toDouble(), DECIMALS)} ${loop}\n"
                 if (buffer.getIntAdj(addr + 8) != 0)
                     break

--- a/src/main/kotlin/rhmodding/tickompiler/gameextractor/GameExtractor.kt
+++ b/src/main/kotlin/rhmodding/tickompiler/gameextractor/GameExtractor.kt
@@ -73,7 +73,9 @@ class GameExtractor(val allSubs: Boolean) {
                 val beats = buffer.getFloat(addr - 0x100000)
                 val seconds = buffer.getInt(addr - 0x100000 + 4) / 32000.0 // will not work with unsigned but not important
                 val bpm = 60 * beats / seconds
-                s += "${correctlyRoundDouble(bpm, DECIMALS)} ${correctlyRoundDouble(beats.toDouble(), DECIMALS)}\n"
+                val loop = buffer.getInt(addr - 0x100000 + 8)
+                println("${loop}")
+                s += "${correctlyRoundDouble(bpm, DECIMALS)} ${correctlyRoundDouble(beats.toDouble(), DECIMALS)} ${loop}\n"
                 if (buffer.getIntAdj(addr + 8) != 0)
                     break
                 addr += 12

--- a/src/main/kotlin/rhmodding/tickompiler/gameputter/GamePutter.kt
+++ b/src/main/kotlin/rhmodding/tickompiler/gameputter/GamePutter.kt
@@ -62,7 +62,7 @@ object GamePutter {
 		tempo.drop(1).forEachIndexed { index, list ->
 			val bpm = list[0].toFloat()
 			val beats = list[1].toFloat()
-			val loop = if (2 >= list.size){  // Check for loop value
+			val loop = if (list.size > 2){  // Check for loop value
 				list[2].toInt()
 			} else {  // Special case for tempo files lacking loop value, behaves exactly as older Tickompiler versions
 				if (index == tempo.size - 2) {

--- a/src/main/kotlin/rhmodding/tickompiler/gameputter/GamePutter.kt
+++ b/src/main/kotlin/rhmodding/tickompiler/gameputter/GamePutter.kt
@@ -62,15 +62,13 @@ object GamePutter {
 		tempo.drop(1).forEachIndexed { index, list ->
 			val bpm = list[0].toFloat()
 			val beats = list[1].toFloat()
-			val loop: Int?
-			if (2 >= list.size){  // Check for loop value
-				loop = list[2].toInt()
-			}
-			else {  // Special case for tempo files lacking loop value, behaves exactly as older Tickompiler versions
+			val loop = if (2 >= list.size){  // Check for loop value
+				list[2].toInt()
+			} else {  // Special case for tempo files lacking loop value, behaves exactly as older Tickompiler versions
 				if (index == tempo.size - 2) {
-					loop = 0x8000
+					0x8000
 				} else {
-					loop = 0
+					0
 				}
 			}
 			val time = 60*beats/bpm

--- a/src/main/kotlin/rhmodding/tickompiler/gameputter/GamePutter.kt
+++ b/src/main/kotlin/rhmodding/tickompiler/gameputter/GamePutter.kt
@@ -62,15 +62,12 @@ object GamePutter {
 		tempo.drop(1).forEachIndexed { index, list ->
 			val bpm = list[0].toFloat()
 			val beats = list[1].toFloat()
+			val loop = list[2].toInt()
 			val time = 60*beats/bpm
 			val timeInt = (time * 32000).roundToInt()
 			result.add(java.lang.Float.floatToIntBits(beats))
 			result.add(timeInt)
-			if (index == tempo.size - 2) {
-				result.add(0x8000)
-			} else {
-				result.add(0)
-			}
+			result.add(loop)
 		}
 		for (i in 0 until 0x1DD) {
 			val one = base.getInt(16*i + 0x1588)

--- a/src/main/kotlin/rhmodding/tickompiler/gameputter/GamePutter.kt
+++ b/src/main/kotlin/rhmodding/tickompiler/gameputter/GamePutter.kt
@@ -62,7 +62,17 @@ object GamePutter {
 		tempo.drop(1).forEachIndexed { index, list ->
 			val bpm = list[0].toFloat()
 			val beats = list[1].toFloat()
-			val loop = list[2].toInt()
+			val loop: Int?
+			if (2 >= list.size){  // Check for loop value
+				loop = list[2].toInt()
+			}
+			else {  // Special case for tempo files lacking loop value, behaves exactly as older Tickompiler versions
+				if (index == tempo.size - 2) {
+					loop = 0x8000
+				} else {
+					loop = 0
+				}
+			}
 			val time = 60*beats/bpm
 			val timeInt = (time * 32000).roundToInt()
 			result.add(java.lang.Float.floatToIntBits(beats))


### PR DESCRIPTION
# Overview
In Megamix's tempo table, there is a value related to how the game loops a song. Currently, Tickompiler does this in regards to said value:

- Check if this is the last tempo (the last non-blank line of the .tempo file) used in the song
- If it isn't the last tempo, set it to `00 00 00 00` (Decimal: *0*)
- If it is the last tempo, set it to `00 80 00 00` (Decimal: *32768*; halts song playback)

**This would cause songs that were meant to loop in-game to not loop once their .tempo files were edited, since these songs would use a loop value of `00 01 00 00` (1) to loop the song.** EpicHaxGuy made note of this in #megamix, which piqued my interest into making it work.

With this pull request, Tickompiler properly exposes this value to the .tempo file, so it can then be manipulated. 

# Examples
## Title Screen (`1000181.tempo`)
### Before:
```
1000181
116.002 4.0
116.0 108.0
```
### Loop value included:
```
1000181
116.002 4.0 0
116.0 108.0 1
```
## Built to Scale (`1000003.tempo`)
### Before:
```
1000003
98.002 26.0
104.001 12.0
108.011 4.0
111.993 12.0
122.075 2.0
128.068 2.0
131.965 12.0
120.0 2.0
106.007 2.0
97.999 12.0
86.022 2.0
70.012 2.0
60.0 12.0
96.0 2.0
115.942 2.0
132.013 12.0
140.023 2.0
150.0 2.0
160.0 20.0

```
### Loop value included:
```
1000003
98.002 26.0 0
104.001 12.0 0
108.011 4.0 0
111.993 12.0 0
122.075 2.0 0
128.068 2.0 0
131.965 12.0 0
120.0 2.0 0
106.007 2.0 0
97.999 12.0 0
86.022 2.0 0
70.012 2.0 0
60.0 12.0 0
96.0 2.0 0
115.942 2.0 0
132.013 12.0 0
140.023 2.0 0
150.0 2.0 0
160.0 20.0 32768
```