### PR TITLE
Bugfixes: round 2

### DIFF
--- a/src/main/kotlin/rhmodding/tickompiler/Functions.kt
+++ b/src/main/kotlin/rhmodding/tickompiler/Functions.kt
@@ -250,16 +250,25 @@ class BytesFunction : Function(-1, "bytes", 1..Int.MAX_VALUE) {
     }
 
     override fun produceTickflow(state: DecompilerState, opcode: Long, specialArg: Long, args: LongArray, comments: CommentType, specialArgStrings: Map<Int, String>): String {
-        return this.name + " " + argsToTickflowArgs(args, specialArgStrings)
+        if (args.size == 0) {
+            return this.name
+        } else {
+            return this.name + " " + argsToTickflowArgs(args, specialArgStrings)
+        }
     }
 }
 
 class OpcodeFunction : Function(-1, "opcode", 0..Integer.MAX_VALUE) {
     override fun produceTickflow(state: DecompilerState, opcode: Long, specialArg: Long, args: LongArray,
                                  comments: CommentType, specialArgStrings: Map<Int, String>): String {
-        return getHex(opcode) +
+        if (args.size == 0) {
+            return getHex(opcode) + addSpecialArg(specialArg)
+        }
+        else {
+            return getHex(opcode) +
                 addSpecialArg(specialArg) +
                 " " + argsToTickflowArgs(args, specialArgStrings)
+        }
     }
 
     override fun produceBytecode(funcCall: FunctionCall): LongArray {
@@ -358,7 +367,12 @@ open class AliasedFunction(opcode: Long, alias: String, argsNeeded: IntRange, va
                                  comments: CommentType, specialArgStrings: Map<Int, String>): String {
         state.nextIndentLevel += indentChange
         state.currentAdjust = currentAdjust
-        return this.name + addSpecialArg(specialArg) + " " + argsToTickflowArgs(args, specialArgStrings)
+        if (args.size == 0) {
+            return this.name + addSpecialArg(specialArg)
+        }
+        else {
+            return this.name + addSpecialArg(specialArg) + " " + argsToTickflowArgs(args, specialArgStrings)
+        }
     }
 
     override fun produceBytecode(funcCall: FunctionCall): LongArray {

--- a/src/main/kotlin/rhmodding/tickompiler/decompiler/Decompiler.kt
+++ b/src/main/kotlin/rhmodding/tickompiler/decompiler/Decompiler.kt
@@ -105,7 +105,8 @@ class Decompiler(val array: ByteArray, val order: ByteOrder, val functions: Func
                     }
                 }
                 if (bytes != 0L) {
-                    val bytes_padded = bytes + if (bytes % 4 == 0L) 0 else (4 - bytes % 4)
+                    if (bytes % 4 == 0L)
+                        bytes += 4 - bytes % 4
                     counter += bytes_padded
                     for (i in 1..bytes_padded) {
                         read()

--- a/src/main/kotlin/rhmodding/tickompiler/decompiler/Decompiler.kt
+++ b/src/main/kotlin/rhmodding/tickompiler/decompiler/Decompiler.kt
@@ -73,8 +73,9 @@ class Decompiler(val array: ByteArray, val order: ByteOrder, val functions: Func
 
         if (useMetadata) {
             builder.append("#index 0x${readInt().toString(16).toUpperCase()}\n")
-            markers[readInt()] = "start"
+            val startPos = readInt()
             markers[readInt()] = "assets"
+            markers[startPos] = "start"
         }
 
         for ((key, value) in macros) {

--- a/src/main/kotlin/rhmodding/tickompiler/decompiler/Decompiler.kt
+++ b/src/main/kotlin/rhmodding/tickompiler/decompiler/Decompiler.kt
@@ -94,8 +94,23 @@ class Decompiler(val array: ByteArray, val order: ByteOrder, val functions: Func
             }
             if (opint == 0xFFFFFFFF) {
                 val amount = readInt()
+                var bytes = 0L
                 for (i in 1..amount) {
-                    anns.add(readInt())
+                    val ann = readInt()
+                    if (ann and 0xFF == 3L) {
+                        bytes = ann ushr 8
+                    }
+                    else {
+                        anns.add(ann)
+                    }
+                }
+                if (bytes != 0L) {
+                    val bytes_padded = bytes + if (bytes % 4 == 0L) 0 else (4 - bytes % 4)
+                    counter += bytes_padded
+                    for (i in 1..bytes_padded) {
+                        read()
+                    }
+                    continue
                 }
                 opint = readInt()
             }

--- a/src/main/kotlin/rhmodding/tickompiler/gameputter/GamePutter.kt
+++ b/src/main/kotlin/rhmodding/tickompiler/gameputter/GamePutter.kt
@@ -35,7 +35,8 @@ object GamePutter {
 						adjArgs.add(annArg)
 					}
 					else if (anncode == 3) {
-						for (a in 1..(annArg/4 + if (annArg % 4 == 0) 0 else (4 - annArg % 4))) {
+						val num_ints = annArg/4 + if (annArg % 4 == 0) 0 else 1
+						for (a in 1..num_ints) {
 							result.add(gameContents.int)
 						}
 					}

--- a/src/main/kotlin/rhmodding/tickompiler/gameputter/GamePutter.kt
+++ b/src/main/kotlin/rhmodding/tickompiler/gameputter/GamePutter.kt
@@ -34,6 +34,11 @@ object GamePutter {
 					if (anncode == 0 || anncode == 1 || anncode == 2) {
 						adjArgs.add(annArg)
 					}
+					else if (anncode == 3) {
+						for (a in 1..(annArg/4 + if (annArg % 4 == 0) 0 else (4 - annArg % 4))) {
+							result.add(gameContents.int)
+						}
+					}
 				}
 				opint = gameContents.int
 			}


### PR DESCRIPTION
After a quick fix for the `goto loc` bug (#16), here's a couple of less urgent bugfixes, these on the decompiler side. Each commit fixes one specific bug.

### No more trailing spaces
Tickompiler's decompiler used to produce the following output per command (regex-like formatting used for clarity)
`$operation(<$arg0>)? ($arguments.join(", "))?`

This means that if there were no arguments, there would be a trailing space at the end of the command. Extra checks have been added to ensure this doesn't happen, for a cleaner experience.

### Make `start` take priority over `assets`
Tickflow's decompiler had the following code:
```kt
markers[readInt()] = "start"
markers[readInt()] = "assets"
```
This meant that if `start` and `assets` had the same value, the output Tickflow would look like this:

```c
// Decompiled with Tickompiler v...
#index X
assets:
tickflow_here
```
Seeing how `start` is required, but `assets` is not, a small change has been added to ensure read order stays the same but `assets` is assigned before `start`. This fix works for most cases, since if `start` matches `assets`, there's a chance they're both at position 0, which is the behavior Tickompiler's compiler defaults to.

### Fix decompilation of Tickflow files with a `bytes` argument annotation

This bug, not unlike the previous one, only realistically applied to decompiling a .bin file that has previously been compiled by Tickompiler, which is why it slipped for so long. This issue would reveal itself in two different ways:

1. Some .bin files would not decompile, giving a `IllegalStateException: reached end of stream`
2. Some .bin files would decompile properly, but most strings would be empty, with some being non-empty but in the wrong place. In some edge cases some markers/labels could be missing.

This is all caused due to the decompiler's "first pass" not managing the `3` argument annotation, which indicates a `bytes` operation. This would cause the first pass to reach end of stream if the `bytes` operation was close enough to the end of the file, potentially skip over some markers, and make the position of strings remembered be offset from the actual position of the strings in the Tickflow. The first pass now properly manages `bytes`.

The packer had a similar error, however, due to not interpreting the contents of the Tickflow, instead copying it, the worst it could do is skip some argument annotations due to reading raw bytes as a Tickflow opint. A fix has also been added for these less frequent but equally destructive situations.