### PR TITLE
docs: warn that they are outdated

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,9 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. warning:
+   This documentation is severely outdated! Please check out Tox's docs `here <https://drive.google.com/drive/folders/1gfrX1GJZhQfz4vR8HyQBV56OqO_rYHGG>` instead.
+
 Welcome to Tickompiler's documentation!
 =======================================
 


### PR DESCRIPTION
ATP it's not worth mantaining these docs (mainly 'cause nobody really wants to work with RST atm)